### PR TITLE
Removed UF From About Page

### DIFF
--- a/about.html
+++ b/about.html
@@ -309,10 +309,6 @@
                     <td>California Polytechnic State University, SLO</td>
                     <td><a href="http://www.cpgd.org/">http://www.cpgd.org</a></td>
                   </tr><tr>
-                    <td>Game Developers' Association, UF</td>
-                    <td>University of Florida</td>
-                    <td><a href="https://orgs.studentinvolvement.ufl.edu/Organization/game-developers-association?fbclid=IwAR1vzMPLyquLajDr8F2svYQL8sk2W3A_pRLTjvp5R6sHVaDctfYFkuSGACE">UF Game Developers' Association</a></td>
-                  </tr><tr>
                     <td>Video Game Development Club, Fullerton</td>
                     <td>CSU Fullerton</td>
                     <td><a href="vgdc.ecs.fullerton.edu/">vgdc.ecs.fullerton.edu/</a></td>


### PR DESCRIPTION
On their request, removing UF from our about page.